### PR TITLE
dvwa adapter 최종 버전 + 이용 가이드

### DIFF
--- a/core/s2nscanner/auth/dvwa_adapter.py
+++ b/core/s2nscanner/auth/dvwa_adapter.py
@@ -35,16 +35,12 @@ class DVWAAdapter:
         self._lock = Lock()
         self._last_auth = None
 
-    # -------------------------------
     # 내부: CSRF 토큰 추출
-    # -------------------------------
     def _extract_user_token(self, text: str) -> Optional[str]:
         match = re.search(r'name=["\']user_token["\']\s+value=["\']([^"\']+)["\']', text)
         return match.group(1) if match else None
 
-    # -------------------------------
     # 로그인 시도
-    # -------------------------------
     def authenticate(self, creds: List[Tuple[str, str]]) -> Optional[Tuple[str, str]]:
         """DVWA 로그인 시도, 성공 시 (username, password) 반환"""
         url = f"{self.base}{self.login_path}"
@@ -67,9 +63,7 @@ class DVWAAdapter:
                 continue
         return None
 
-    # -------------------------------
     # 세션 유지 여부 검사
-    # -------------------------------
     def is_authenticated(self) -> bool:
         """index.php 요청 시 로그인 상태면 True"""
         try:
@@ -80,9 +74,7 @@ class DVWAAdapter:
         except Exception:
             return False
 
-    # -------------------------------
     # 세션 자동 유지
-    # -------------------------------
     def ensure_authenticated(self, creds: List[Tuple[str, str]], retries=1):
         """세션이 끊기면 자동으로 재로그인"""
         if self.is_authenticated():
@@ -94,16 +86,12 @@ class DVWAAdapter:
             time.sleep(1)
         return False
 
-    # -------------------------------
     # 공용 client 반환
-    # -------------------------------
     def get_client(self) -> HttpClient:
         """현재 세션이 담긴 HttpClient 반환"""
         return self._client
 
-    # -------------------------------
     # 쿠키 저장/복원
-    # -------------------------------
     def save_cookies(self, path: str):
         """현재 세션 쿠키를 JSON으로 저장"""
         try:


### PR DESCRIPTION
## 🧩 PR 제목 규칙
> [FEAT] add DVWAAdapter + HttpClient for shared session/auth management


## 개요 (Overview)
DVWA 전용 인증/세션 관리기(`DVWAAdapter`)와 공용 HTTP 세션 래퍼(`HttpClient`)를 추가합니다.
이를 통해 여러 플러그인(예: oscommand, sqlinjection 등)이 동일한 로그인 세션(쿠키)을 재사용할 수 있어,
인증이 필요한 테스트를 안정적으로 수행할 수 있습니다.

핵심 목적:
- 플러그인 간 인증 상태 일관성 유지
- 중복된 로그인 로직 제거
- 테스트 자동화 지원


## 변경 사항 (Changes)
core/s2nscanner/http/client.py
- requests.Session 기반 HttpClient 추가
- 공용 get / post 메서드 구현
- 재시도(retry) 및 백오프(backoff) 기능 내장

core/s2nscanner/auth/dvwa_adapter.py
- DVWAAdapter 추가 (로그인·세션·쿠키 관리)
- 주요 기능:
authenticate() : 로그인 시도
is_authenticated() : 세션 유지 확인
ensure_authenticated() : 자동 재로그인
save_cookies() / load_cookies() : 쿠키 저장 및 복원
core/s2nscanner/utils/url.py
normalize_base_url() 및 resolve_base_url() 추가
환경변수, CLI 인자, 설정파일 등에서 base URL을 자동으로 결정


## ✅ 체크리스트 (Checklist)
- [x] 코드 스타일 및 린트 검사 통과  
- [x] 관련 테스트 작성 및 통과  
- [x] 관련 문서 (README 등) 업데이트  
- [x] 리뷰어에게 충분히 이해될 수 있는 설명 작성  


## ✅ 플러그인에서 사용하는 방법 (Usage Guide)
- 상세한 적용 예시는 oscommand 플러그인 PR에 작성하겠습니다.

1️⃣ HttpClient 단독 사용 (비인증 플러그인)
- 이 방식은 인증이 필요 없는 스캐너에서 사용 (예: XSS, 디렉터리 인덱싱 등)
```
# core/s2nscanner/plugins/xss.py (예시)
from core.s2nscanner.http.client import HttpClient

client = HttpClient()

resp = client.get("http://localhost/dvwa/vulnerabilities/xss/")
print(resp.status_code)
```

2️⃣ DVWAAdapter를 통한 인증 세션 공유
- 이 방식은 로그인 후 세션을 필요로 하는 스캐너에서 사용 (예: OS Command, SQLi 등)
```
# core/s2nscanner/plugins/oscommand.py (예시)
from core.s2nscanner.auth.dvwa_adapter import DVWAAdapter

# 1. 어댑터 초기화 (DVWA 로그인 페이지 기준)
adapter = DVWAAdapter(base_url="http://localhost/dvwa")

# 2. 로그인 보장 (세션이 없으면 자동 로그인)
adapter.ensure_authenticated([("admin", "password")])

# 3. 로그인된 세션(client)을 플러그인 내부에서 재사용
client = adapter.get_client()

# 이후 모든 요청은 로그인된 세션 상태로 수행됨
r = client.get("http://localhost/dvwa/vulnerabilities/exec/")
print(r.status_code)
```

3️⃣ 여러 플러그인 간 세션 공유
- main.py 혹은 CLI 실행 진입점에서 한 번만 인증을 수행한 뒤, 다른 플러그인들에게 같은 client 객체를 전달하면 됩니다.
- **이 구조를 사용하면 모든 플러그인이 동일한 로그인 세션을 공유하므로,
불필요한 재로그인 없이 효율적인 스캔이 가능합니다.**
```
# core/s2nscanner/main.py
from core.s2nscanner.auth.dvwa_adapter import DVWAAdapter
from core.s2nscanner.plugins import oscommand, sqlinjection, xss

adapter = DVWAAdapter(base_url="http://localhost/dvwa")
adapter.ensure_authenticated([("admin", "password")])

shared_client = adapter.get_client()

# 플러그인별로 같은 세션(client)을 전달
oscommand.run_scan(shared_client)
sqlinjection.run_scan(shared_client)
xss.run_scan(shared_client)
```
## 💬 비고 (Notes)
- DVWAAdapter는 구조상 다른 CMS(WebGoat 등) 어댑터로도 확장 가능
-모든 플러그인은 직접 requests를 호출하지 말고 HttpClient 인스턴스를 주입받아야 함
- 쿠키/세션을 유지한 상태에서 인증된 스캔 수행 가능
- 쿠키를 JSON으로 저장할 수 있어 재실행 시 빠른 복원 가능
```
adapter.save_cookies("dvwa_session.json")
adapter.load_cookies("dvwa_session.json")
```