### PR TITLE
feat: report 기능 구현

### DIFF
--- a/s2n/s2nscanner/report.py
+++ b/s2n/s2nscanner/report.py
@@ -7,7 +7,7 @@ ScanReport를 다양한 형식(JSON, HTML, CSV, CONSOLE)으로 변환하고 출�
 import csv
 import json
 import traceback
-from dataclasses import asdict, fields
+from dataclasses import asdict
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Any
@@ -32,35 +32,7 @@ def _serialize_datetime(obj: Any) -> str:
 
 def _scan_report_to_dict(report: ScanReport) -> Dict[str, Any]:
     """ScanReport를 딕셔너리로 변환 (datetime은 ISO 형식으로)"""
-    result = {}
-    for field in fields(report):
-        value = getattr(report, field.name)
-        if isinstance(value, datetime):
-            result[field.name] = value.isoformat()
-        elif hasattr(value, "__dict__") or hasattr(value, "_asdict"):
-            # dataclass인 경우
-            try:
-                result[field.name] = asdict(value)
-            except TypeError:
-                # nested dataclass 처리
-                if isinstance(value, list):
-                    result[field.name] = [
-                        asdict(item) if hasattr(item, "__dict__") else item
-                        for item in value
-                    ]
-                else:
-                    result[field.name] = str(value)
-        elif isinstance(value, list):
-            result[field.name] = [
-                asdict(item) if hasattr(item, "__dict__") else item for item in value
-            ]
-        elif isinstance(value, dict):
-            result[field.name] = {
-                k: asdict(v) if hasattr(v, "__dict__") else v for k, v in value.items()
-            }
-        else:
-            result[field.name] = value
-    return result
+    return json.loads(json.dumps(asdict(report), default=_serialize_datetime))
 
 
 def format_report_to_json(report: ScanReport, pretty_print: bool = True) -> JSONOutput:


### PR DESCRIPTION
## Feat/ Finding Module
> 플러그인 처리 모듈과 CLI 옵션을 인자로 받아 `ScanReport` 단계에 필요한 인자를 리턴하는 함수 모듈을 만들었습니다.

---

## 개요 (Overview)

 `Finding`을 인자로 받아 `ScanReport`를 생성하는 함수 모듈을 만들었습니다.

### 안내 

**2025/11/11**에 리팩터링 커밋까지 남기고 다시 push 하겠습니다!

## 코드 설명

가장 윗단위의 함수(가장 먼저 호출되는 함수, 콜스택 하단)부터 간략히 작성하겠습니다.

### output_report

`output_report` 함수는 `finding.py`의 반환값을 인자로 넘겨받아 실행됩니다.
```python
def output_report(
    report: ScanReport,
    config: OutputConfig
) -> None:
```
함수의 인자 `config` 객체의 `format` 필드 설정에 따라 스캔 결과를 다음 옵션에 따라 제공합니다:

1. 콘솔 프린트
2. `JSON`
3. HTML
4. CSV
5. MULTI

기본적으로 4개의 버전과 `MULTI` 옵션으로 스캔 결과를 html, csv, json, printf 모두로 제공합니다. (임시)
이 부분은 추후 `cli` 옵션 파라미터 설정과 함께 수정할 필요가 있습니다. 

**refactor**: PR을 올리면서 코드를 다시보니, `save_report` 함수를 활용할 필요가 있어보입니다. 불필요한 함수는 제거한 뒤, 함수를 최대한 활용하도록 하겠습니다.

```python
# output_report 함수의 이어지는 부분입니다.
    if config.format == OutputFormat.CONSOLE:
    # 중략 ...
    
    elif config.format == OutputFormat.JSON:
    # 중략 ...
    
    elif config.format == OutputFormat.HTML:
    # 중략 ...
   # 중략 ...
    
    elif config.format == OutputFormat.MULTI:
        # 여러 형식으로 동시 출력
        base_path = config.path or Path("report")
        
       # 생략 ...

```

### `save_report`

`ScanReport`를 **지정된 형식으로 파일로 저장**합니다. 

```python
def save_report(
    report: ScanReport, # 저장할 스캔 리포트
    output_path: Path, # 출력 파일 경로
    output_format: OutputFormat = OutputFormat.JSON, # 출력 형식
    pretty_print: bool = True # JSON의 경우 보기 좋게 포맷팅할지 
) -> None:
```
저장과 관련된 함수이며, json, html, csv 파일 저장 함수를 분기처리합니다.

```python
if output_format == OutputFormat.JSON:
        content = format_report_to_json(report, pretty_print=pretty_print)
        output_path.write_text(content, encoding='utf-8')
    
    elif output_format == OutputFormat.HTML:
        content = format_report_to_html(report)
        output_path.write_text(content, encoding='utf-8')
    
    elif output_format == OutputFormat.CSV:
        content = format_report_to_csv(report)
        output_path.write_text(content, encoding='utf-8')
    
    else:
        raise ValueError(f"Unsupported output format: {output_format}")

```

### `format_report_to_{JSON | HTML | CSV}`

이 부분부터 코드 리뷰에서 확인해주시면 됩니다!
https://github.com/504s2n/s2n/pull/37/files

---

## 변경 사항 (Changes)
- `s2nscanner/report.py`에 추가

[데이터 모델 문서](https://www.notion.so/S2N-2a79e3e335cc80c58722d1e6cac01269)에 스펙을 준수하여 구현했습니다.

### PR 문서 이어서 작성 중...


## 🔍 관련 이슈 (Issue)
없음


## ✅ 체크리스트 (Checklist)
- [x] 코드 스타일 및 린트 검사 통과  
- [x] 관련 테스트 작성 및 통과  
- [x] 관련 문서 (README 등) 업데이트  
- [x] 리뷰어에게 충분히 이해될 수 있는 설명 작성  


---

## 💬 비고 (Notes)
리뷰어에게 전달할 추가 정보나 주의사항이 있다면 적어주세요.