### PR TITLE
test: csrf 테스트 코드 작성

### DIFF
--- a/s2n/s2nscanner/plugins/csrf/test/test_csrf_main.py
+++ b/s2n/s2nscanner/plugins/csrf/test/test_csrf_main.py
@@ -1,0 +1,44 @@
+from types import SimpleNamespace
+from s2n.s2nscanner.plugins.csrf import csrf_main
+from s2n.s2nscanner.plugins.csrf import csrf_scan as csrf_scan_module
+from s2n.s2nscanner.interfaces import Finding, PluginStatus, Severity, PluginResult
+
+
+def make_mock_plugin_context(http_client, target_urls):
+    scan_context = SimpleNamespace(http_client=http_client)
+    plugin_context = SimpleNamespace(
+        plugin_name="csrf",
+        scan_context=scan_context,
+        plugin_config=None,
+        target_urls=target_urls,
+        logger=None,
+    )
+    return plugin_context
+
+
+def test_main_run_uses_csrf_scan(monkeypatch):
+    # arrange: replace csrf_scan with a stub that returns a Finding list
+    fake_finding = Finding(
+        id="1",
+        plugin="csrf",
+        severity=Severity.INFO,
+        title="fake",
+        description="fake",
+    )
+
+    # monkeypatch csrf_scan function to return a list
+    monkeypatch.setattr(csrf_scan_module, "csrf_scan", lambda url, http_client=None, plugin_context=None: [fake_finding])
+
+    # mock http client exposing .s (session)
+    session = SimpleNamespace(headers={})
+    http_client = SimpleNamespace(s=session)
+    plugin_context = make_mock_plugin_context(http_client, ["http://example.local"]) 
+
+    scanner = csrf_main.main()
+    result = scanner.run(plugin_context)  # type: ignore[arg-type]
+
+    # result should be a PluginResult dataclass
+    assert isinstance(result, PluginResult)
+    assert len(result.findings) == 1
+    # When findings present, status should be PARTIAL
+    assert result.status == PluginStatus.PARTIAL

--- a/s2n/s2nscanner/plugins/csrf/test/test_csrf_scan.py
+++ b/s2n/s2nscanner/plugins/csrf/test/test_csrf_scan.py
@@ -1,0 +1,77 @@
+from types import SimpleNamespace
+
+from s2n.s2nscanner.plugins.csrf import csrf_scan as csrf_scan_module
+from s2n.s2nscanner.plugins.csrf.test.test_data import (
+    HTML_WITH_CSRF_TOKEN,
+    HTML_WITHOUT_CSRF,
+    HTML_NO_FORMS,
+)
+
+
+class MockRequest:
+    def __init__(self):
+        self.headers = {"Host": "example.com"}
+        self._cookies = {}
+
+
+class MockResponse:
+    def __init__(self, text, headers=None):
+        self.text = text
+        self.headers = headers or {}
+        self.request = MockRequest()
+
+
+class MockSession:
+    def __init__(self, text, headers=None):
+        self.headers = headers or {}
+        self._text = text
+
+    def get(self, _url, timeout=10):
+        # keep references to avoid unused-argument lint complaints
+        _ = _url
+        _ = timeout
+        return MockResponse(self._text, headers={})
+
+
+def test_scan_html_detects_and_missing_token():
+    resp = SimpleNamespace(request=MockRequest())
+    found = csrf_scan_module.scan_html(HTML_WITH_CSRF_TOKEN, resp, "http://t")
+    assert "Token" in found.title
+    assert found.severity.name == "INFO"
+
+    missing = csrf_scan_module.scan_html(HTML_WITHOUT_CSRF, resp, "http://t")
+    assert "Not Found" in missing.title
+    assert missing.severity.name == "HIGH"
+
+
+def test_scan_res_headers_checks_presence():
+    # missing headers -> MEDIUM severity
+    missing = csrf_scan_module.scan_res_headers({})
+    assert missing.severity.name == "MEDIUM"
+    assert "Missing CSRF Protection Headers" in missing.title
+
+    ok = csrf_scan_module.scan_res_headers({"X-Frame-Options": "DENY", "Content-Security-Policy": "", "SameSite": "Lax"})
+    assert ok.severity.name == "INFO"
+
+
+def test_scan_form_tags_variants():
+    resp = SimpleNamespace(request=MockRequest())
+
+    no_forms = csrf_scan_module.scan_form_tags(HTML_NO_FORMS, resp, "http://t")
+    assert "No Form Tags Found" in no_forms.title
+
+    missing = csrf_scan_module.scan_form_tags(HTML_WITHOUT_CSRF, resp, "http://t")
+    assert missing.severity.name == "HIGH"
+    assert "Form(s) Missing CSRF Token" in missing.title
+
+    ok = csrf_scan_module.scan_form_tags(HTML_WITH_CSRF_TOKEN, resp, "http://t")
+    assert ok.severity.name == "INFO"
+
+
+def test_csrf_scan_integration_with_mock_session():
+    session = MockSession(HTML_WITHOUT_CSRF)
+    http_client = SimpleNamespace(s=session)
+    results = csrf_scan_module.csrf_scan("http://example.local", http_client=http_client, plugin_context=None)  # type: ignore
+    # csrf_scan returns a list of three Finding objects (html_result, http_result, html_form_result)
+    assert isinstance(results, list)
+    assert len(results) == 3

--- a/s2n/s2nscanner/plugins/csrf/test/test_csrf_utils.py
+++ b/s2n/s2nscanner/plugins/csrf/test/test_csrf_utils.py
@@ -1,0 +1,28 @@
+from s2n.s2nscanner.plugins.csrf.csrf_utils import FormParser
+from s2n.s2nscanner.plugins.csrf.test.test_data import HTML_WITH_CSRF_TOKEN, HTML_WITHOUT_CSRF
+
+
+def test_formparser_parses_forms_and_inputs():
+    parser = FormParser()
+    parser.feed(HTML_WITH_CSRF_TOKEN)
+    forms = parser.forms
+    assert isinstance(forms, list)
+    assert len(forms) == 1
+    form = forms[0]
+    assert "inputs" in form
+    inputs = form["inputs"]
+    # should contain at least the csrf hidden input and username
+    names = [i.get("name", "") for i in inputs]
+    assert "csrf_token" in names or any("csrf" in n for n in names)
+
+
+def test_formparser_handles_no_forms():
+    parser = FormParser()
+    parser.feed(HTML_WITHOUT_CSRF)
+    forms = parser.forms
+    assert isinstance(forms, list)
+    assert len(forms) == 1
+    form = forms[0]
+    inputs = form["inputs"]
+    # should not find hidden csrf input
+    assert not any(i.get("type", "").lower() == "hidden" for i in inputs)

--- a/s2n/s2nscanner/plugins/csrf/test/test_data.py
+++ b/s2n/s2nscanner/plugins/csrf/test/test_data.py
@@ -1,0 +1,25 @@
+"""Reusable test data for CSRF plugin tests."""
+
+HTML_WITH_CSRF_TOKEN = '''
+<html>
+  <body>
+    <form action="/submit" method="post">
+      <input type="hidden" name="csrf_token" value="abc123" />
+      <input type="text" name="username" />
+    </form>
+  </body>
+</html>
+'''
+
+HTML_WITHOUT_CSRF = '''
+<html>
+  <body>
+    <form action="/login" method="post">
+      <input type="text" name="username" />
+      <input type="password" name="password" />
+    </form>
+  </body>
+</html>
+'''
+
+HTML_NO_FORMS = '<html><head></head><body><p>No forms here</p></body></html>'


### PR DESCRIPTION
# test: add pytest suite for CSRF plugin (unit + integration, test data)

> [test]: CSRF 플러그인에 대한 단위 및 통합 테스트 추가, 테스트 데이터 모듈 분리

<details>
<summary>
PR 제목 규칙
</summary>
태그 종류:
- `feat`: 새로운 기능 추가  
- `fix`: 버그 및 기타 코드 fix  
- `refactor`: 코드 리팩토링  
- `test`: 테스트 코드 관련  
- `docs`: 문서 수정  
- `chore`: 빌드/환경 설정, 의존성 관리 등 
</details>

---

## 개요 (Overview)

CSRF 플러그인(s2nscanner/plugins/csrf)에 대해 pytest 기반의 테스트 스위트를 추가합니다.  
모듈 레벨과 함수(함수/클래스) 레벨 테스트를 작성하고, 테스트에서 재사용하는 HTML fixtures를 별도 모듈(test_data.py)으로 분리했습니다. 린트 및 문법 오류를 수정하여 pytest 실행 준비를 완료했습니다.

---

## 변경 사항 (Changes)
- s2n/s2nscanner/plugins/csrf/test/test_data.py
  - 테스트용 HTML fixtures (HTML_WITH_CSRF_TOKEN, HTML_WITHOUT_CSRF, HTML_NO_FORMS 등)
- s2n/s2nscanner/plugins/csrf/test/test_csrf_utils.py
  - FormParser 유닛 테스트 (폼/인풋 파싱, 무폼 케이스)
- s2n/s2nscanner/plugins/csrf/test/test_csrf_scan.py
  - csrf_scan 모듈의 함수 단위 테스트 및 통합(모의 세션 사용) 테스트
- s2n/s2nscanner/plugins/csrf/test/test_csrf_main.py
  - csrf_main(상위 실행 흐름) 통합 스타일 테스트(필요 함수 monkeypatch)
- 경미한 린트/문법 수정(테스트 코드 내 오타 및 import 정리)

---

## ✅ 체크리스트 (Checklist)
- [x] 코드 스타일 및 린트 검사 통과 (테스트 코드 기준으로 검토/수정)
- [x] 관련 테스트 작성 및 추가
- [ ] 관련 문서 (README 등) 업데이트
- [x] 리뷰어에게 충분히 이해될 수 있는 설명 작성

---

## 🔍 관련 이슈 (Issue)
> 없음

---

## 💬 비고 (Notes)
- 로컬 실행:
  - 가상환경 활성화: source .envs/python/.venv/bin/activate (프로젝트 루트에서)
  - pytest 실행: pytest -q s2n/s2nscanner/plugins/csrf/test
- 테스트는 외부 네트워크를 사용하지 않도록 requests/session을 모킹합니다.
- 필요 시 CI 워크플로(예: GitHub Actions)에서 pytest 실행을 추가하면 좋습니다.
```# test: add pytest suite for CSRF plugin (unit + integration, test data)
