### PR TITLE
Fix/xss: 테스트 파일 경로 참조 수정

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,213 @@
+# conftest.py
+import sys
+import json
+import pytest
+from pathlib import Path
+import shutil
+
+
+# ========================================
+# 1. 프로젝트 루트 동적 탐색
+# ========================================
+def find_project_root(start_path=None):
+    """
+    .git 또는 pyproject.toml을 찾아 프로젝트 루트 반환
+    테스트 파일 위치가 바뀌어도 안정적
+    """
+    if start_path is None:
+        start_path = Path(__file__).resolve()
+
+    current = Path(start_path)
+
+    while current != current.parent:
+        if (current / ".git").exists() or (current / "pyproject.toml").exists():
+            return current
+        current = current.parent
+
+    # fallback: 현재 파일 기준 상위
+    return Path(start_path).resolve().parent
+
+
+PROJECT_ROOT = find_project_root()
+
+
+# ========================================
+# 2. sys.path 자동 보정
+# ========================================
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+
+# ========================================
+# 3. 페이로드 파일 동적 탐색
+# ========================================
+def find_payload_file(filename="xss_payloads.json"):
+    """
+    xss_payloads.json을 프로젝트에서 찾기
+    1. 예상 경로 우선 확인 (빠름)
+    2. 없으면 전체 검색 (느리지만 확실)
+    """
+    # 예상 경로들 (구조 변경 대비)
+    expected_paths = [
+        PROJECT_ROOT / "s2n" / "s2nscanner" / "plugins" / "xss" / filename,
+        PROJECT_ROOT / "s2n" / "plugins" / "xss" / filename,
+        PROJECT_ROOT / "plugins" / "xss" / filename,
+    ]
+
+    for path in expected_paths:
+        if path.exists():
+            return path
+
+    # 전체 검색 (최후 수단)
+    for path in PROJECT_ROOT.rglob(filename):
+        if path.is_file():
+            return path
+
+    return None
+
+
+# ========================================
+# 4. Import 절대경로 사용
+# ========================================
+try:
+    from s2n.s2nscanner.interfaces import (
+        PluginContext, ScanContext, PluginConfig,
+        PluginResult, PluginStatus, Severity, Confidence,
+        ScanConfig
+    )
+    from s2n.s2nscanner.http.client import HttpClient
+    HAS_INTERFACES = True
+except ImportError:
+    # fallback
+    from types import SimpleNamespace
+    HAS_INTERFACES = False
+
+    class PluginContext(SimpleNamespace):
+        pass
+
+    class ScanContext(SimpleNamespace):
+        pass
+
+    class PluginConfig(SimpleNamespace):
+        pass
+
+    class PluginResult(SimpleNamespace):
+        pass
+
+    class PluginStatus:
+        SUCCESS = "success"
+        FAILED = "failed"
+        SKIPPED = "skipped"
+        PARTIAL = "partial"
+
+    class Severity:
+        HIGH = "HIGH"
+
+    class Confidence:
+        FIRM = "firm"
+
+    class ScanConfig(SimpleNamespace):
+        pass
+
+    import requests
+
+    class HttpClient:
+        def __init__(self):
+            self.s = requests.Session()
+
+        def get(self, *args, **kwargs):
+            return self.s.get(*args, **kwargs)
+
+        def post(self, *args, **kwargs):
+            return self.s.post(*args, **kwargs)
+
+
+# test_xss_fixtures 절대경로 import
+from test_xss_fixtures import SAMPLE_PAYLOADS_JSON
+
+
+# ========================================
+# 5. Fixtures
+# ========================================
+@pytest.fixture(scope="session")
+def sample_payloads():
+    """테스트용 페이로드 리스트"""
+    from test_xss_fixtures import SAMPLE_PAYLOADS
+    return SAMPLE_PAYLOADS
+
+
+@pytest.fixture(scope="session")
+def payload_path(tmp_path_factory):
+    """
+    실제 xss_payloads.json을 동적으로 찾아 임시 경로에 복사
+    경로 구조가 바뀌어도 작동
+    """
+    real_payload = find_payload_file("xss_payloads.json")
+
+    tmp_dir = tmp_path_factory.mktemp("xss")
+    tmp_payload = tmp_dir / "xss_payloads.json"
+
+    if real_payload and real_payload.exists():
+        shutil.copy(real_payload, tmp_payload)
+    else:
+        # fallback: 샘플 데이터 생성
+        tmp_payload.write_text(
+            json.dumps(SAMPLE_PAYLOADS_JSON, ensure_ascii=False),
+            encoding="utf-8"
+        )
+
+    return tmp_payload
+
+
+@pytest.fixture
+def mock_http_client():
+    """HttpClient wrapper 모킹"""
+    client = HttpClient()
+    return client
+
+
+@pytest.fixture
+def plugin_context_factory(mock_http_client):
+    """PluginContext 생성 헬퍼"""
+    from datetime import datetime, timezone
+    import time
+
+    def _factory(target_urls=None, plugin_config=None):
+        if target_urls is None:
+            target_urls = ["https://test.com"]
+
+        if plugin_config is None:
+            plugin_config = PluginConfig(
+                enabled=True,
+                timeout=5,
+                max_payloads=50,
+                custom_params={}
+            )
+
+        scan_config = ScanConfig(target_url=target_urls[0] if target_urls else "")
+
+        scan_context = ScanContext(
+            scan_id=f"test-{int(time.time())}",
+            start_time=datetime.now(timezone.utc),
+            config=scan_config,
+            http_client=mock_http_client,
+            crawler=None
+        )
+
+        return PluginContext(
+            plugin_name="xss",
+            scan_context=scan_context,
+            plugin_config=plugin_config,
+            target_urls=target_urls,
+            logger=None
+        )
+
+    return _factory
+
+
+@pytest.fixture
+def responses_mock():
+    """responses 라이브러리 HTTP 모킹"""
+    responses_lib = pytest.importorskip("responses")
+    with responses_lib.RequestsMock() as rsps:
+        yield rsps

--- a/test/test_xss_unit.py
+++ b/test/test_xss_unit.py
@@ -109,7 +109,7 @@ def test_form_parser_basic_form():
 def test_form_parser_csrf_field():
     """CSRF 토큰 필드 포함 form"""
     from s2n.s2nscanner.plugins.xss.xss_scanner import FormParser
-    from .test_xss_fixtures import FORM_WITH_CSRF_HTML
+    from test_xss_fixtures import FORM_WITH_CSRF_HTML
 
     parser = FormParser()
     parser.feed(FORM_WITH_CSRF_HTML)
@@ -212,7 +212,7 @@ def test_input_point_detector_from_query(responses_mock, mock_http_client):
 def test_input_point_detector_from_form(responses_mock, mock_http_client):
     """HTML form 입력 지점 탐지"""
     from s2n.s2nscanner.plugins.xss.xss_scanner import InputPointDetector
-    from .test_xss_fixtures import FORM_WITH_CSRF_HTML
+    from test_xss_fixtures import FORM_WITH_CSRF_HTML
 
     responses_mock.get("https://app.test/form", body=FORM_WITH_CSRF_HTML, status=200)
 


### PR DESCRIPTION
# 개요 (Overview)

기존 xss 플러그인의 테스트 코드 파일의 경로가 이동됨에 따라,
파일 내 경로 탐색을 수정했습니다.

# 변경 사항 (Changes)
test/conftest.py (경로 이동 및 경로 탐색 내용 수정)
✅ 프로젝트 루트 동적 탐색 (find_project_root())
✅ sys.path 자동 보정
✅ 페이로드 파일 동적 검색 (find_payload_file())
✅ 절대 경로 import 사용
test/test_xss_unit.py (경로 탐색 내용 수정)
✅ 112행: from .test_xss_fixtures → from test_xss_fixtures
✅ 215행: from .test_xss_fixtures → from test_xss_fixtures
