### PR TITLE
[FIX] CLI에 --output-format 옵션 추가

### DIFF
--- a/docs/interfaces.en.md
+++ b/docs/interfaces.en.md
@@ -66,9 +66,9 @@ Output Types (JSONOutput, HTMLOutput, ConsoleOutput)
 - Purpose: Top-level data structure for a scan request
 - Usage timing: After parsing CLI arguments or when calling the Python API
 
-| Field             | Type                   | Required | Default   | Description                   |
-| ----------------- | ---------------------- | -------- | --------- | ----------------------------- |
-| `target_url`    | `str`                | ✅       | -         | URL to scan                   |
+| Field           | Type                 | Required | Default | Description                   |
+| --------------- | -------------------- | -------- | ------- | ----------------------------- |
+| `target_url`    | `str`                | ✅       | -       | URL to scan                   |
 | `plugins`       | `List[str]`          | ❌       | `[]`    | List of plugins to use        |
 | `config_path`   | `Optional[Path]`     | ❌       | `None`  | Path to configuration file    |
 | `auth_type`     | `Optional[AuthType]` | ❌       | `None`  | Authentication type           |
@@ -83,18 +83,19 @@ Output Types (JSONOutput, HTMLOutput, ConsoleOutput)
 
 Fields:
 
-| Field             | Type                   | Required | Description                   |
-| ----------------- | ---------------------- | -------- | ----------------------------- |
-| `url` | `str` | ✅ | `--url`, `-u` |
-| `plugin` | `List[str]` | ❌ | `--plugin`, `-p` (multiple allowed) |
-| `config` | `Optional[str]` | ❌ | `--config`, `-c` |
-| `auth` | `Optional[str]` | ❌ | `--auth`, `-a`|
-| `username` | `Optional[str]` | ❌ | `--username` |
-| `password` | `Optional[str]` | ❌ | `--password` |
-| `output` | `Optional[str]` | ❌ | `--output`, `-o` |
-| `depth` | `int` | ❌ | `--depth`, `-d` (default: `2`) |
-| `verbose` | `bool` | ❌ | `--verbose`, `-v` |
-| `log_file` | `Optional[str]` | ❌ | `--log-file` |
+| Field           | Type            | Required | Description                         |
+| --------------- | --------------- | -------- | ----------------------------------- |
+| `url`           | `str`           | ✅       | `--url`, `-u`                       |
+| `plugin`        | `List[str]`     | ❌       | `--plugin`, `-p` (multiple allowed) |
+| `config`        | `Optional[str]` | ❌       | `--config`, `-c`                    |
+| `auth`          | `Optional[str]` | ❌       | `--auth`, `-a`                      |
+| `username`      | `Optional[str]` | ❌       | `--username`                        |
+| `password`      | `Optional[str]` | ❌       | `--password`                        |
+| `output`        | `Optional[str]` | ❌       | `--output`, `-o`                    |
+| `output_format` | `Optional[str]` | ❌       | `--output-format`                   |
+| `depth`         | `int`           | ❌       | `--depth`, `-d` (default: `2`)      |
+| `verbose`       | `bool`          | ❌       | `--verbose`, `-v`                   |
+| `log_file`      | `Optional[str]` | ❌       | `--log-file`                        |
 
 ---
 
@@ -105,15 +106,15 @@ Fields:
 - Purpose: Manage the overall scan configuration
 - Usage timing: After `ScanRequest` is created, before scan execution
 
-| Field             | Type                      | Default | Description                   |
-| ----------------- | ------------------------- | ------- | ----------------------------- |
-| `target_url`      | `str`                     | -       | URL to scan                   |
-| `scanner_config`  | `ScannerConfig`           | -       | Scanner engine settings       |
-| `plugin_configs`  | `Dict[str, PluginConfig]` | `{}`    | Per-plugin configurations     |
-| `auth_config`     | `Optional[AuthConfig]`    | `None`  | Authentication settings        |
-| `network_config`  | `NetworkConfig`           | -       | Network settings              |
-| `output_config`   | `OutputConfig`            | -       | Output settings               |
-| `logging_config`  | `LoggingConfig`           | -       | Logging settings              |
+| Field            | Type                      | Default | Description               |
+| ---------------- | ------------------------- | ------- | ------------------------- |
+| `target_url`     | `str`                     | -       | URL to scan               |
+| `scanner_config` | `ScannerConfig`           | -       | Scanner engine settings   |
+| `plugin_configs` | `Dict[str, PluginConfig]` | `{}`    | Per-plugin configurations |
+| `auth_config`    | `Optional[AuthConfig]`    | `None`  | Authentication settings   |
+| `network_config` | `NetworkConfig`           | -       | Network settings          |
+| `output_config`  | `OutputConfig`            | -       | Output settings           |
+| `logging_config` | `LoggingConfig`           | -       | Logging settings          |
 
 Creation methods:
 
@@ -128,16 +129,16 @@ Creation methods:
 - Purpose: Scanner engine runtime settings
 - Usage timing: Part of `ScanConfig`
 
-| Field             | Type   | Default                | Range      | Description                   |
-| ----------------- | ------ | ---------------------- | ---------- | ----------------------------- |
-| `crawl_depth`     | `int`  | `2`                    | 1-10       | Crawl depth                   |
-| `max_threads`     | `int`  | `5`                    | 1-20       | Maximum threads               |
-| `timeout`         | `int`  | `30`                   | 1-300      | Request timeout (seconds)     |
-| `max_retries`     | `int`  | `3`                    | 0-10       | Maximum retry attempts        |
-| `retry_delay`     | `float`| `1.0`                  | 0.1-10.0   | Retry delay (seconds)         |
-| `user_agent`      | `str`  | `"S2N-Scanner/0.1.0"`   | -          | User-Agent header             |
-| `follow_redirects`| `bool` | `True`                 | -          | Follow redirects              |
-| `verify_ssl`      | `bool` | `True`                 | -          | Verify SSL certificates       |
+| Field              | Type    | Default               | Range    | Description               |
+| ------------------ | ------- | --------------------- | -------- | ------------------------- |
+| `crawl_depth`      | `int`   | `2`                   | 1-10     | Crawl depth               |
+| `max_threads`      | `int`   | `5`                   | 1-20     | Maximum threads           |
+| `timeout`          | `int`   | `30`                  | 1-300    | Request timeout (seconds) |
+| `max_retries`      | `int`   | `3`                   | 0-10     | Maximum retry attempts    |
+| `retry_delay`      | `float` | `1.0`                 | 0.1-10.0 | Retry delay (seconds)     |
+| `user_agent`       | `str`   | `"S2N-Scanner/0.1.0"` | -        | User-Agent header         |
+| `follow_redirects` | `bool`  | `True`                | -        | Follow redirects          |
+| `verify_ssl`       | `bool`  | `True`                | -        | Verify SSL certificates   |
 
 ---
 
@@ -146,15 +147,15 @@ Creation methods:
 - Purpose: Configuration for an individual plugin
 - Usage timing: Part of `ScanConfig.plugin_configs`
 
-| Field               | Type                | Default | Description                        |
-| ------------------- | ------------------- | ------- | ---------------------------------- |
-| `enabled`           | `bool`              | `True`  | Whether the plugin is enabled      |
-| `timeout`           | `int`               | `30`    | Plugin timeout                     |
-| `max_payloads`      | `Optional[int]`     | `None`  | Maximum number of payloads         |
-| `payload_file`      | `Optional[Path]`    | `None`  | Custom payload file                |
-| `severity_threshold`| `Severity`          | `LOW`   | Minimum severity to report         |
-| `skip_patterns`     | `List[str]`         | `[]`    | URL patterns to skip               |
-| `custom_params`     | `Dict[str, Any]`    | `{}`    | Plugin-specific custom parameters  |
+| Field                | Type             | Default | Description                       |
+| -------------------- | ---------------- | ------- | --------------------------------- |
+| `enabled`            | `bool`           | `True`  | Whether the plugin is enabled     |
+| `timeout`            | `int`            | `30`    | Plugin timeout                    |
+| `max_payloads`       | `Optional[int]`  | `None`  | Maximum number of payloads        |
+| `payload_file`       | `Optional[Path]` | `None`  | Custom payload file               |
+| `severity_threshold` | `Severity`       | `LOW`   | Minimum severity to report        |
+| `skip_patterns`      | `List[str]`      | `[]`    | URL patterns to skip              |
+| `custom_params`      | `Dict[str, Any]` | `{}`    | Plugin-specific custom parameters |
 
 Example (SQL Injection plugin):
 
@@ -177,15 +178,15 @@ PluginConfig(
 - Purpose: Authentication settings
 - Usage timing: Part of `ScanConfig`
 
-| Field       | Type                | Required | Default | Description            |
-| ----------- | ------------------- | -------- | ------- | ---------------------- |
-| `auth_type` | `AuthType`          | ✅       | -       | Authentication type    |
-| `username`  | `Optional[str]`     | ❌       | `None`  | Username               |
-| `password`  | `Optional[str]`     | ❌       | `None`  | Password               |
-| `token`     | `Optional[str]`     | ❌       | `None`  | Bearer token           |
-| `api_key`   | `Optional[str]`     | ❌       | `None`  | API key                |
-| `headers`   | `Dict[str, str]`    | ❌       | `{}`    | Custom headers         |
-| `cookies`   | `Dict[str, str]`    | ❌       | `{}`    | Cookies                |
+| Field       | Type             | Required | Default | Description         |
+| ----------- | ---------------- | -------- | ------- | ------------------- |
+| `auth_type` | `AuthType`       | ✅       | -       | Authentication type |
+| `username`  | `Optional[str]`  | ❌       | `None`  | Username            |
+| `password`  | `Optional[str]`  | ❌       | `None`  | Password            |
+| `token`     | `Optional[str]`  | ❌       | `None`  | Bearer token        |
+| `api_key`   | `Optional[str]`  | ❌       | `None`  | API key             |
+| `headers`   | `Dict[str, str]` | ❌       | `{}`    | Custom headers      |
+| `cookies`   | `Dict[str, str]` | ❌       | `{}`    | Cookies             |
 
 AuthType Enum:
 
@@ -203,14 +204,14 @@ AuthType Enum:
 - Purpose: Network layer settings
 - Usage timing: Part of `ScanConfig`
 
-| Field              | Type             | Default | Description                        |
-| ------------------ | ---------------- | ------- | ---------------------------------- |
-| `max_connections`  | `int`            | `100`   | Maximum concurrent connections     |
-| `connection_timeout`| `int`            | `10`    | Connection timeout (seconds)      |
-| `read_timeout`     | `int`            | `30`    | Read timeout (seconds)             |
-| `rate_limit`       | `Optional[float]`| `None`  | Maximum requests per second        |
-| `proxy`            | `Optional[str]`  | `None`  | Proxy URL                          |
-| `dns_cache_ttl`    | `int`            | `300`   | DNS cache TTL (seconds)            |
+| Field                | Type              | Default | Description                    |
+| -------------------- | ----------------- | ------- | ------------------------------ |
+| `max_connections`    | `int`             | `100`   | Maximum concurrent connections |
+| `connection_timeout` | `int`             | `10`    | Connection timeout (seconds)   |
+| `read_timeout`       | `int`             | `30`    | Read timeout (seconds)         |
+| `rate_limit`         | `Optional[float]` | `None`  | Maximum requests per second    |
+| `proxy`              | `Optional[str]`   | `None`  | Proxy URL                      |
+| `dns_cache_ttl`      | `int`             | `300`   | DNS cache TTL (seconds)        |
 
 ---
 
@@ -219,14 +220,14 @@ AuthType Enum:
 - Purpose: Output settings
 - Usage timing: Part of `ScanConfig`
 
-| Field              | Type             | Default   | Description                   |
-| ------------------ | ---------------- | --------- | ----------------------------- |
-| `format`           | `OutputFormat`   | `JSON`    | Output format                 |
-| `path`             | `Optional[Path]`| `None`    | Output file path              |
-| `pretty_print`     | `bool`           | `True`    | JSON pretty print             |
-| `include_timestamps`| `bool`          | `True`    | Include timestamps            |
-| `include_metadata` | `bool`           | `True`    | Include metadata              |
-| `console_mode`     | `ConsoleMode`    | `SUMMARY` | Console output mode           |
+| Field                | Type             | Default   | Description         |
+| -------------------- | ---------------- | --------- | ------------------- |
+| `format`             | `OutputFormat`   | `JSON`    | Output format       |
+| `path`               | `Optional[Path]` | `None`    | Output file path    |
+| `pretty_print`       | `bool`           | `True`    | JSON pretty print   |
+| `include_timestamps` | `bool`           | `True`    | Include timestamps  |
+| `include_metadata`   | `bool`           | `True`    | Include metadata    |
+| `console_mode`       | `ConsoleMode`    | `SUMMARY` | Console output mode |
 
 OutputFormat Enum:
 
@@ -250,14 +251,14 @@ ConsoleMode Enum:
 - Purpose: Logging settings
 - Usage timing: Part of `ScanConfig`
 
-| Field           | Type             | Default                                      | Description                        |
-| --------------- | ---------------- | -------------------------------------------- | ---------------------------------- |
-| `level`         | `LogLevel`       | `INFO`                                       | Log level                          |
-| `file_path`     | `Optional[Path]`| `None`                                       | Log file path                      |
-| `console_output`| `bool`           | `True`                                       | Whether to print logs to console   |
-| `format`        | `str`            | `"%(asctime)s - %(levelname)s - %(message)s"`| Log format                         |
-| `max_file_size` | `int`            | `10485760`                                   | Max file size (bytes)              |
-| `backup_count`  | `int`            | `3`                                          | Number of backup files             |
+| Field            | Type             | Default                                       | Description                      |
+| ---------------- | ---------------- | --------------------------------------------- | -------------------------------- |
+| `level`          | `LogLevel`       | `INFO`                                        | Log level                        |
+| `file_path`      | `Optional[Path]` | `None`                                        | Log file path                    |
+| `console_output` | `bool`           | `True`                                        | Whether to print logs to console |
+| `format`         | `str`            | `"%(asctime)s - %(levelname)s - %(message)s"` | Log format                       |
+| `max_file_size`  | `int`            | `10485760`                                    | Max file size (bytes)            |
+| `backup_count`   | `int`            | `3`                                           | Number of backup files           |
 
 LogLevel Enum:
 
@@ -276,16 +277,16 @@ LogLevel Enum:
 - Purpose: Shared context during scan execution
 - Usage timing: Created at scan start, passed to plugins
 
-| Field            | Type             | Description                   |
-| ---------------- | ---------------- | ----------------------------- |
-| `scan_id`        | `str`            | Unique scan ID (UUID)         |
-| `start_time`     | `datetime`       | Scan start time               |
-| `config`         | `ScanConfig`     | Scan configuration            |
-| `http_client`    | `HTTPClient`     | HTTP client instance          |
-| `crawler`        | `Crawler`        | Crawler instance              |
-| `session_data`   | `Dict[str, Any]` | Session data                  |
-| `discovered_urls`| `Set[str]`       | Discovered URLs               |
-| `visited_urls`   | `Set[str]`       | Visited URLs                  |
+| Field             | Type             | Description           |
+| ----------------- | ---------------- | --------------------- |
+| `scan_id`         | `str`            | Unique scan ID (UUID) |
+| `start_time`      | `datetime`       | Scan start time       |
+| `config`          | `ScanConfig`     | Scan configuration    |
+| `http_client`     | `HTTPClient`     | HTTP client instance  |
+| `crawler`         | `Crawler`        | Crawler instance      |
+| `session_data`    | `Dict[str, Any]` | Session data          |
+| `discovered_urls` | `Set[str]`       | Discovered URLs       |
+| `visited_urls`    | `Set[str]`       | Visited URLs          |
 
 ---
 
@@ -294,13 +295,13 @@ LogLevel Enum:
 - Purpose: Context provided when running a plugin
 - Usage timing: Created for each plugin execution
 
-| Field           | Type           | Description                   |
-| --------------- | -------------- | ----------------------------- |
-| `plugin_name`   | `str`          | Plugin name                   |
-| `scan_context`  | `ScanContext`  | Global scan context           |
-| `plugin_config` | `PluginConfig` | Plugin configuration          |
-| `target_urls`   | `List[str]`    | URLs for the plugin to scan   |
-| `logger`        | `Logger`       | Logger instance               |
+| Field           | Type           | Description                 |
+| --------------- | -------------- | --------------------------- |
+| `plugin_name`   | `str`          | Plugin name                 |
+| `scan_context`  | `ScanContext`  | Global scan context         |
+| `plugin_config` | `PluginConfig` | Plugin configuration        |
+| `target_urls`   | `List[str]`    | URLs for the plugin to scan |
+| `logger`        | `Logger`       | Logger instance             |
 
 ---
 
@@ -311,27 +312,27 @@ LogLevel Enum:
 - Purpose: Individual vulnerability information
 - Usage timing: Created when a vulnerability is detected
 
-| Field          | Type                    | Required | Default | Description                        |
-| -------------- | ----------------------- | -------- | ------- | ---------------------------------- |
-| `id`           | `str`                   | ✅       | -       | Unique ID (e.g. "sql-001")         |
-| `plugin`       | `str`                   | ✅       | -       | Plugin name                        |
-| `severity`     | `Severity`              | ✅       | -       | Severity                           |
-| `title`        | `str`                   | ✅       | -       | Vulnerability title                |
-| `description`  | `str`                   | ✅       | -       | Detailed description               |
-| `url`          | `Optional[str]`         | ❌       | `None`  | URL where it was found             |
-| `parameter`    | `Optional[str]`         | ❌       | `None`  | Vulnerable parameter name           |
-| `method`       | `Optional[str]`         | ❌       | `None`  | HTTP method                        |
-| `payload`      | `Optional[str]`         | ❌       | `None`  | Attack payload                     |
-| `evidence`     | `Optional[str]`         | ❌       | `None`  | Evidence of vulnerability          |
-| `request`      | `Optional[HTTPRequest]` | ❌       | `None`  | Request information                |
-| `response`     | `Optional[HTTPResponse]`| ❌       | `None`  | Response information               |
-| `remediation`  | `Optional[str]`         | ❌       | `None`  | Remediation guidance               |
-| `references`   | `List[str]`             | ❌       | `[]`    | Reference links                    |
-| `cwe_id`       | `Optional[str]`         | ❌       | `None`  | CWE ID                             |
-| `cvss_score`   | `Optional[float]`       | ❌       | `None`  | CVSS score (0.0-10.0)              |
-| `cvss_vector`  | `Optional[str]`         | ❌       | `None`  | CVSS vector                        |
-| `confidence`   | `Confidence`            | ❌       | `MEDIUM`| Confidence level                   |
-| `timestamp`    | `datetime`              | -        | -       | Discovery time (automatic)         |
+| Field         | Type                     | Required | Default  | Description                |
+| ------------- | ------------------------ | -------- | -------- | -------------------------- |
+| `id`          | `str`                    | ✅       | -        | Unique ID (e.g. "sql-001") |
+| `plugin`      | `str`                    | ✅       | -        | Plugin name                |
+| `severity`    | `Severity`               | ✅       | -        | Severity                   |
+| `title`       | `str`                    | ✅       | -        | Vulnerability title        |
+| `description` | `str`                    | ✅       | -        | Detailed description       |
+| `url`         | `Optional[str]`          | ❌       | `None`   | URL where it was found     |
+| `parameter`   | `Optional[str]`          | ❌       | `None`   | Vulnerable parameter name  |
+| `method`      | `Optional[str]`          | ❌       | `None`   | HTTP method                |
+| `payload`     | `Optional[str]`          | ❌       | `None`   | Attack payload             |
+| `evidence`    | `Optional[str]`          | ❌       | `None`   | Evidence of vulnerability  |
+| `request`     | `Optional[HTTPRequest]`  | ❌       | `None`   | Request information        |
+| `response`    | `Optional[HTTPResponse]` | ❌       | `None`   | Response information       |
+| `remediation` | `Optional[str]`          | ❌       | `None`   | Remediation guidance       |
+| `references`  | `List[str]`              | ❌       | `[]`     | Reference links            |
+| `cwe_id`      | `Optional[str]`          | ❌       | `None`   | CWE ID                     |
+| `cvss_score`  | `Optional[float]`        | ❌       | `None`   | CVSS score (0.0-10.0)      |
+| `cvss_vector` | `Optional[str]`          | ❌       | `None`   | CVSS vector                |
+| `confidence`  | `Confidence`             | ❌       | `MEDIUM` | Confidence level           |
+| `timestamp`   | `datetime`               | -        | -        | Discovery time (automatic) |
 
 ### Severity Enum
 
@@ -354,13 +355,13 @@ LogLevel Enum:
 - Purpose: HTTP request information
 - Usage timing: Part of `Finding`
 
-| Field     | Type                | Description     |
-| --------- | ------------------- | --------------- |
-| `method`  | `str`               | HTTP method     |
-| `url`     | `str`               | Request URL     |
-| `headers` | `Dict[str, str]`    | Request headers |
-| `body`    | `Optional[str]`     | Request body    |
-| `cookies` | `Dict[str, str]`    | Cookies         |
+| Field     | Type             | Description     |
+| --------- | ---------------- | --------------- |
+| `method`  | `str`            | HTTP method     |
+| `url`     | `str`            | Request URL     |
+| `headers` | `Dict[str, str]` | Request headers |
+| `body`    | `Optional[str]`  | Request body    |
+| `cookies` | `Dict[str, str]` | Cookies         |
 
 ---
 
@@ -369,12 +370,12 @@ LogLevel Enum:
 - Purpose: HTTP response information
 - Usage timing: Part of `Finding`
 
-| Field        | Type             | Description                        |
-| ------------ | ---------------- | ---------------------------------- |
-| `status_code`| `int`            | Status code                        |
-| `headers`    | `Dict[str, str]` | Response headers                   |
-| `body`       | `str`            | Response body (max 10KB)           |
-| `elapsed_ms` | `float`          | Response time (milliseconds)       |
+| Field         | Type             | Description                  |
+| ------------- | ---------------- | ---------------------------- |
+| `status_code` | `int`            | Status code                  |
+| `headers`     | `Dict[str, str]` | Response headers             |
+| `body`        | `str`            | Response body (max 10KB)     |
+| `elapsed_ms`  | `float`          | Response time (milliseconds) |
 
 ---
 
@@ -383,18 +384,18 @@ LogLevel Enum:
 - Purpose: Plugin execution result
 - Usage timing: Created after each plugin execution
 
-| Field             | Type                    | Description                   |
-| ----------------- | ----------------------- | ----------------------------- |
-| `plugin_name`     | `str`                   | Plugin name                   |
-| `status`          | `PluginStatus`          | Execution status              |
-| `findings`        | `List[Finding]`         | List of found vulnerabilities |
-| `start_time`      | `datetime`              | Start time                    |
-| `end_time`        | `datetime`              | End time                      |
-| `duration_seconds`| `float`                | Duration (seconds)            |
-| `urls_scanned`    | `int`                   | Number of URLs scanned        |
-| `requests_sent`   | `int`                   | Number of requests sent       |
-| `error`           | `Optional[PluginError]` | Error information             |
-| `metadata`        | `Dict[str, Any]`        | Additional metadata           |
+| Field              | Type                    | Description                   |
+| ------------------ | ----------------------- | ----------------------------- |
+| `plugin_name`      | `str`                   | Plugin name                   |
+| `status`           | `PluginStatus`          | Execution status              |
+| `findings`         | `List[Finding]`         | List of found vulnerabilities |
+| `start_time`       | `datetime`              | Start time                    |
+| `end_time`         | `datetime`              | End time                      |
+| `duration_seconds` | `float`                 | Duration (seconds)            |
+| `urls_scanned`     | `int`                   | Number of URLs scanned        |
+| `requests_sent`    | `int`                   | Number of requests sent       |
+| `error`            | `Optional[PluginError]` | Error information             |
+| `metadata`         | `Dict[str, Any]`        | Additional metadata           |
 
 PluginStatus Enum:
 
@@ -411,18 +412,18 @@ PluginStatus Enum:
 - Purpose: Full scan report
 - Usage timing: Created at scan completion
 
-| Field             | Type                | Description                   |
-| ----------------- | ------------------- | ----------------------------- |
-| `scan_id`         | `str`               | Unique scan ID                |
-| `target_url`      | `str`               | Target URL                    |
-| `scanner_version` | `str`               | Scanner version               |
-| `start_time`      | `datetime`          | Start time                    |
-| `end_time`        | `datetime`          | End time                      |
-| `duration_seconds`| `float`             | Total duration                |
-| `config`          | `ScanConfig`        | Used configuration            |
-| `plugin_results`  | `List[PluginResult]`| List of plugin results        |
-| `summary`         | `ScanSummary`       | Summary information           |
-| `metadata`        | `ScanMetadata`      | Metadata                      |
+| Field              | Type                 | Description            |
+| ------------------ | -------------------- | ---------------------- |
+| `scan_id`          | `str`                | Unique scan ID         |
+| `target_url`       | `str`                | Target URL             |
+| `scanner_version`  | `str`                | Scanner version        |
+| `start_time`       | `datetime`           | Start time             |
+| `end_time`         | `datetime`           | End time               |
+| `duration_seconds` | `float`              | Total duration         |
+| `config`           | `ScanConfig`         | Used configuration     |
+| `plugin_results`   | `List[PluginResult]` | List of plugin results |
+| `summary`          | `ScanSummary`        | Summary information    |
+| `metadata`         | `ScanMetadata`       | Metadata               |
 
 ---
 
@@ -431,16 +432,16 @@ PluginStatus Enum:
 - Purpose: Summary of scan results
 - Usage timing: Part of `ScanReport`
 
-| Field                  | Type                  | Description                        |
-| ---------------------- | --------------------- | ---------------------------------- |
-| `total_vulnerabilities`| `int`                 | Total number of vulnerabilities    |
-| `severity_counts`      | `Dict[Severity, int]` | Counts per severity                |
-| `plugin_counts`        | `Dict[str, int]`      | Counts per plugin                  |
-| `total_urls_scanned`   | `int`                 | Total scanned URLs                 |
-| `total_requests`       | `int`                 | Total requests                     |
-| `success_rate`         | `float`               | Success rate (%)                   |
-| `has_critical`         | `bool`                | Whether any Critical issues exist   |
-| `has_high`             | `bool`                | Whether any High issues exist      |
+| Field                   | Type                  | Description                       |
+| ----------------------- | --------------------- | --------------------------------- |
+| `total_vulnerabilities` | `int`                 | Total number of vulnerabilities   |
+| `severity_counts`       | `Dict[Severity, int]` | Counts per severity               |
+| `plugin_counts`         | `Dict[str, int]`      | Counts per plugin                 |
+| `total_urls_scanned`    | `int`                 | Total scanned URLs                |
+| `total_requests`        | `int`                 | Total requests                    |
+| `success_rate`          | `float`               | Success rate (%)                  |
+| `has_critical`          | `bool`                | Whether any Critical issues exist |
+| `has_high`              | `bool`                | Whether any High issues exist     |
 
 ---
 
@@ -449,14 +450,14 @@ PluginStatus Enum:
 - Purpose: Scan metadata
 - Usage timing: Part of `ScanReport`
 
-| Field           | Type                  | Description                        |
-| --------------- | --------------------- | ---------------------------------- |
-| `hostname`      | `str`                 | Hostname where executed            |
-| `username`      | `str`                 | Executing user                     |
-| `python_version`| `str`                 | Python version                     |
-| `os_info`       | `str`                 | OS information                     |
-| `cli_args`      | `Optional[List[str]]` | CLI arguments (if run via CLI)     |
-| `config_file`   | `Optional[str]`       | Path to configuration file         |
+| Field            | Type                  | Description                    |
+| ---------------- | --------------------- | ------------------------------ |
+| `hostname`       | `str`                 | Hostname where executed        |
+| `username`       | `str`                 | Executing user                 |
+| `python_version` | `str`                 | Python version                 |
+| `os_info`        | `str`                 | OS information                 |
+| `cli_args`       | `Optional[List[str]]` | CLI arguments (if run via CLI) |
+| `config_file`    | `Optional[str]`       | Path to configuration file     |
 
 ---
 
@@ -467,12 +468,12 @@ PluginStatus Enum:
 - Purpose: Base class for all S2N exceptions
 - Usage timing: Raised when errors occur during scan execution
 
-| Field       | Type                | Description            |
-| ----------- | ------------------- | ---------------------- |
-| `message`   | `str`               | Error message          |
-| `error_code`| `str`               | Error code             |
-| `timestamp` | `datetime`          | Occurrence time        |
-| `context`   | `Dict[str, Any]`    | Additional context     |
+| Field        | Type             | Description        |
+| ------------ | ---------------- | ------------------ |
+| `message`    | `str`            | Error message      |
+| `error_code` | `str`            | Error code         |
+| `timestamp`  | `datetime`       | Occurrence time    |
+| `context`    | `Dict[str, Any]` | Additional context |
 
 Subclasses:
 
@@ -490,15 +491,15 @@ Subclasses:
 - Purpose: Error information report
 - Usage timing: Created when errors are captured
 
-| Field         | Type                | Description                   |
-| ------------- | ------------------- | ----------------------------- |
-| `error_type`  | `str`               | Error type                    |
-| `message`     | `str`               | Error message                 |
-| `traceback`   | `Optional[str]`     | Stack trace                   |
-| `timestamp`   | `datetime`          | Occurrence time               |
-| `context`     | `Dict[str, Any]`    | Error context                 |
-| `recoverable` | `bool`              | Whether it is recoverable     |
-| `retry_count` | `int`               | Retry count                   |
+| Field         | Type             | Description               |
+| ------------- | ---------------- | ------------------------- |
+| `error_type`  | `str`            | Error type                |
+| `message`     | `str`            | Error message             |
+| `traceback`   | `Optional[str]`  | Stack trace               |
+| `timestamp`   | `datetime`       | Occurrence time           |
+| `context`     | `Dict[str, Any]` | Error context             |
+| `recoverable` | `bool`           | Whether it is recoverable |
+| `retry_count` | `int`            | Retry count               |
 
 ---
 
@@ -531,12 +532,12 @@ Structure:
 - Purpose: Data for console output
 - Usage timing: Created for console output generation
 
-| Field           | Type                    | Description                   |
-| --------------- | ----------------------- | ----------------------------- |
-| `mode`          | `ConsoleMode`           | Output mode                   |
-| `summary_lines` | `List[str]`            | Summary lines                 |
-| `detail_lines`  | `List[str]`            | Detail lines                  |
-| `progress_info` | `Optional[ProgressInfo]`| Progress information          |
+| Field           | Type                     | Description          |
+| --------------- | ------------------------ | -------------------- |
+| `mode`          | `ConsoleMode`            | Output mode          |
+| `summary_lines` | `List[str]`              | Summary lines        |
+| `detail_lines`  | `List[str]`              | Detail lines         |
+| `progress_info` | `Optional[ProgressInfo]` | Progress information |
 
 ---
 
@@ -545,12 +546,12 @@ Structure:
 - Purpose: Progress information
 - Usage timing: Part of `ConsoleOutput`
 
-| Field        | Type   | Description                   |
-| ------------ | ------ | ----------------------------- |
-| `current`    | `int`  | Current progress              |
-| `total`      | `int`  | Total count                   |
-| `percentage` | `float`| Progress percentage (%)       |
-| `message`    | `str`  | Progress message              |
+| Field        | Type    | Description             |
+| ------------ | ------- | ----------------------- |
+| `current`    | `int`   | Current progress        |
+| `total`      | `int`   | Total count             |
+| `percentage` | `float` | Progress percentage (%) |
+| `message`    | `str`   | Progress message        |
 
 ---
 

--- a/docs/interfaces.ko.md
+++ b/docs/interfaces.ko.md
@@ -18,6 +18,7 @@
 ### 목적
 
 S2N Scanner의 모든 데이터 흐름에서 사용되는 공통 타입을 정의합니다.
+
 - **CLI 방식**과 **Python Import 방식** 모두 동일한 타입 사용
 - 각 단계(입력 → 설정 → 실행 → 결과 → 출력)별 타입 명확화
 - 타입 안전성 및 데이터 일관성 보장
@@ -93,6 +94,7 @@ Output Types (JSONOutput, HTMLOutput, ConsoleOutput)
 | `username` | `Optional[str]` | ❌ | `--username` |
 | `password` | `Optional[str]` | ❌ | `--password` |
 | `output` | `Optional[str]` | ❌ | `--output, -o` |
+| `output_format` | `Optional[str]` | ❌ | `--output-format` |
 | `depth` | `int` | ❌ | `--depth, -d` (기본값: 2) |
 | `verbose` | `bool` | ❌ | `--verbose, -v` |
 | `log_file` | `Optional[str]` | ❌ | `--log-file` |
@@ -160,6 +162,7 @@ Output Types (JSONOutput, HTMLOutput, ConsoleOutput)
 | `custom_params` | `Dict[str, Any]` | `{}` | 플러그인별 커스텀 파라미터 |
 
 **예시 (SQL Injection 플러그인)**:
+
 ```python
 PluginConfig(
     enabled=True,
@@ -190,6 +193,7 @@ PluginConfig(
 | `cookies` | `Dict[str, str]` | `{}` | 쿠키 |
 
 **AuthType Enum**:
+
 - `NONE`: 인증 없음
 - `BASIC`: HTTP Basic Auth
 - `BEARER`: Bearer Token
@@ -230,6 +234,7 @@ PluginConfig(
 | `console_mode` | `ConsoleMode` | `SUMMARY` | 콘솔 출력 모드 |
 
 **OutputFormat Enum**:
+
 - `JSON`: JSON 파일
 - `HTML`: HTML 리포트
 - `CSV`: CSV 파일
@@ -237,6 +242,7 @@ PluginConfig(
 - `MULTI`: 다중 형식
 
 **ConsoleMode Enum**:
+
 - `SILENT`: 출력 없음
 - `SUMMARY`: 요약만
 - `VERBOSE`: 상세 출력
@@ -259,6 +265,7 @@ PluginConfig(
 | `backup_count` | `int` | `3` | 백업 파일 개수 |
 
 **LogLevel Enum**:
+
 - `DEBUG`
 - `INFO`
 - `WARNING`
@@ -332,6 +339,7 @@ PluginConfig(
 | `timestamp` | `datetime` | - | 발견 시간 (자동) |
 
 **Severity Enum**:
+
 - `CRITICAL`: 치명적
 - `HIGH`: 높음
 - `MEDIUM`: 중간
@@ -339,6 +347,7 @@ PluginConfig(
 - `INFO`: 정보성
 
 **Confidence Enum**:
+
 - `CERTAIN`: 확실
 - `FIRM`: 확고
 - `TENTATIVE`: 잠정적
@@ -393,6 +402,7 @@ PluginConfig(
 | `metadata` | `Dict[str, Any]` | 추가 메타데이터 |
 
 **PluginStatus Enum**:
+
 - `SUCCESS`: 성공
 - `PARTIAL`: 부분 성공
 - `FAILED`: 실패
@@ -470,6 +480,7 @@ PluginConfig(
 | `context` | `Dict[str, Any]` | 추가 컨텍스트 |
 
 **하위 클래스**:
+
 - `NetworkError`: 네트워크 관련 에러
 - `AuthenticationError`: 인증 실패
 - `ConfigurationError`: 설정 오류
@@ -503,6 +514,7 @@ PluginConfig(
 **용도**: JSON 출력 형식
 
 **구조**:
+
 ```json
 {
   "scan_id": "uuid",
@@ -609,6 +621,5 @@ for result in report.plugin_results:
 ```
 
 ---
-
 
 이 문서의 모든 타입은 `s2n/s2nscanner/interfaces.py`에 구현됩니다.

--- a/s2n/s2nscanner/cli/config_builder.py
+++ b/s2n/s2nscanner/cli/config_builder.py
@@ -10,6 +10,7 @@ from s2n.s2nscanner.interfaces import (
     AuthConfig,
     AuthType,
     PluginConfig,
+    ConsoleMode,
 )
 
 
@@ -38,7 +39,7 @@ def build_scan_config(
         format=req.output_format,
         path=req.output_path,
         pretty_print=True,
-        console_mode=("DEBUG" if req.verbose else "SUMMARY"),
+        console_mode=(ConsoleMode.DEBUG if req.verbose else ConsoleMode.SUMMARY),
     )
 
     # 로깅 설정 구성

--- a/s2n/s2nscanner/cli/mapper.py
+++ b/s2n/s2nscanner/cli/mapper.py
@@ -22,14 +22,30 @@ def cliargs_to_scanrequest(args: CLIArguments) -> ScanRequest:
                 auth_type = AuthType(upper_auth)
             except ValueError:
                 raise ValidationError(f"Unknown auth type: {args.auth}")
-        
+
+    # OutputFormat 매핑
+    output_format = OutputFormat.JSON
+    if args.output_format:
+        try:
+            output_format = OutputFormat(args.output_format.upper())
+        except ValueError:
+            raise ValidationError(f"Unknown output format: {args.output_format}")
+    elif args.output:
+        suffix = Path(args.output).suffix.lower()
+        if suffix == ".html":
+            output_format = OutputFormat.HTML
+        elif suffix == ".csv":
+            output_format = OutputFormat.CSV
+        elif suffix == ".json":
+            output_format = OutputFormat.JSON
+    
     # 변환 수행
     return ScanRequest(
         target_url=args.url,
         plugins=args.plugin or [],
         config_path=Path(args.config) if args.config else None,
         auth_type=auth_type,
-        output_format=OutputFormat.JSON,
+        output_format=output_format,
         output_path=Path(args.output) if args.output else None,
         verbose=args.verbose,
     )

--- a/s2n/s2nscanner/cli/runner.py
+++ b/s2n/s2nscanner/cli/runner.py
@@ -46,9 +46,16 @@ def cli():
 @click.option("--username", help="인증용 사용자명")
 @click.option("--password", help="인증용 비밀번호")
 @click.option("-o", "--output", help="결과 출력 파일 경로 (예: result.json)")
+@click.option(
+    "--output-format",
+    type=click.Choice([fmt.value for fmt in OutputFormat], case_sensitive=False),
+    default=OutputFormat.JSON.value,
+    show_default=True,
+    help="결과 출력 형식 (JSON, HTML, CSV, CONSOLE, MULTI)",
+)
 @click.option("-v", "--verbose", is_flag=True, help="상세 로그 출력")
 @click.option("--log-file", help="로그 파일 경로")
-def scan(url, plugin, auth, username, password, output, verbose, log_file):
+def scan(url, plugin, auth, username, password, output, output_format, verbose, log_file):
     logger = init_logger(verbose, log_file)
     logger.info("Starting scan for %s", url)
 
@@ -60,6 +67,7 @@ def scan(url, plugin, auth, username, password, output, verbose, log_file):
         username=username,
         password=password,
         output=output,
+        output_format=output_format,
         verbose=verbose,
         log_file=log_file,
     )

--- a/s2n/s2nscanner/interfaces.py
+++ b/s2n/s2nscanner/interfaces.py
@@ -95,6 +95,7 @@ class CLIArguments:
     username: Optional[str] = None
     password: Optional[str] = None
     output: Optional[str] = None
+    output_format: Optional[str] = None
     depth: int = 2
     verbose: bool = False
     log_file: Optional[str] = None


### PR DESCRIPTION
# [FIX] CLI에 --output-format 옵션 추가

## 개요 (Overview)
- CLI에 --output-format 옵션을 추가해 JSON/HTML/CSV/CONSOLE/MULTI를 선택 가능하게 했고 CLIArguments에 필드를 추가했습니다.
- mapper에서 CLI입력을 ScanRequest로 변환할 때 --output-format을 매핑하고, --output 확장자 기반 추론도 추가했습니다.
- config_builder에서 콘솔 모드를 문자열이 아닌 ConsoleMode enum으로 설정하게 수정했습니다.
- 인터페이스 문서에 --output--format 필드를 반영했습니다.


## 변경 사항 (Changes)
<img width="609" height="194" alt="image" src="https://github.com/user-attachments/assets/29d1d544-6c66-46be-bde2-1f71f7f0378a" />
로컬에서 --output-format console으로 실행했을 때 위와 같이 report가 나오는 것을 확인했습니다.

---

## ✅ 체크리스트 (Checklist)
- [ ] 코드 스타일 및 린트 검사 통과  
- [ ] 관련 테스트 작성 및 통과  
- [ ] 관련 문서 (README 등) 업데이트  
- [ ] 리뷰어에게 충분히 이해될 수 있는 설명 작성  

---

## 🔍 관련 이슈 (Issue)
> 관련된 이슈 번호+링크를 적어주세요.  
> 예: `Closes #123` 또는 `Fixes #45`

---

## 💬 비고 (Notes)
리뷰어에게 전달할 추가 정보나 주의사항이 있다면 적어주세요.