### PR TITLE
fix: require explicit --ai-provider, remove auto choice

### DIFF
--- a/s2n/s2nscanner/cli/runner.py
+++ b/s2n/s2nscanner/cli/runner.py
@@ -144,9 +144,10 @@ def cli():
 )
 @click.option(
     "--ai-provider",
-    type=click.Choice(["auto", "ollama", "huggingface", "anthropic", "claude", "openai", "gpt"], case_sensitive=False),
+    type=click.Choice(["ollama", "huggingface", "anthropic", "claude", "openai", "gpt"], case_sensitive=False),
     default=None,
-    help="LLM provider / AI 공급자 (기본: auto — Ollama 우선, 안 되면 HuggingFace). "
+    help="LLM provider / AI 공급자 — --ai-mode가 off가 아니면 반드시 지정해야 함 "
+    "(자동으로 Ollama/HuggingFace가 선택되지 않음). "
     "s2n-agent의 S2NAGENT_PROVIDER 환경변수로도 지정 가능",
 )
 @click.option(
@@ -334,7 +335,10 @@ def scan(
             # Agent가 항상 첫 번째로 실행되도록 prepend
             all_plugins = [agent_plugin] + _regular_instances
 
-            _provider_label = ai_provider or "auto"
+            # ai_provider가 비어 있어도 여기까지 왔다는 건 S2NAGENT_PROVIDER 환경변수로
+            # provider가 해석됐다는 뜻이다 — 그렇지 않으면 S2NAgentPlugin() 생성자에서
+            # 이미 ValueError가 발생해 아래 except 절로 빠진다.
+            _provider_label = ai_provider or os.environ.get("S2NAGENT_PROVIDER", "(env)")
             console.print(f"[cyan]🤖 S2N-Agent 활성화: mode={ai_mode}, model={ai_model}, provider={_provider_label}[/cyan]")
 
             if not agent_plugin.is_available():
@@ -353,6 +357,9 @@ def scan(
                 "[yellow]⚠️  s2nagent 패키지 미설치 — AI 모드 비활성화. "
                 "`pip install s2n-agent` 실행 필요.[/yellow]"
             )
+        except ValueError as exc:
+            console.print(f"[red]❌ AI provider 오류: {exc}[/red]")
+            sys.exit(1)
 
     scanner = Scanner(
         config=config,

--- a/test/unit/test_runner.py
+++ b/test/unit/test_runner.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import re
 from types import SimpleNamespace
 from datetime import datetime
 
@@ -199,3 +200,79 @@ def test_scan_output_report_error_returns_failure(cli_runner, monkeypatch, fake_
 
     assert result.exit_code == 1
     assert "Failed to output report: boom" in result.output
+
+
+def test_ai_mode_without_provider_exits_with_clear_error(cli_runner, fake_common, monkeypatch):
+    """s2n-agent는 provider를 명시하지 않으면 Ollama/HuggingFace로 자동 선택하지 않고
+    ValueError를 던진다 — runner가 이걸 잡아서 traceback 대신 명확한 CLI 오류로 보여줘야 한다."""
+    monkeypatch.delenv("S2NAGENT_PROVIDER", raising=False)
+
+    result = cli_runner.invoke(
+        runner_mod.scan,
+        [
+            "--url",
+            "http://example.com",
+            "--plugin",
+            "oscommand",
+            "--output",
+            "result.json",
+            "--ai-mode",
+            "smart",
+        ],
+    )
+
+    assert result.exit_code == 1, f"expected failure, got: {result.output}"
+    assert "provider" in result.output.lower()
+
+
+def test_ai_mode_with_explicit_provider_activates_agent(cli_runner, fake_common, monkeypatch):
+    """provider를 명시하면 AI 모드가 정상적으로 활성화된다."""
+    monkeypatch.delenv("S2NAGENT_PROVIDER", raising=False)
+
+    result = cli_runner.invoke(
+        runner_mod.scan,
+        [
+            "--url",
+            "http://example.com",
+            "--plugin",
+            "oscommand",
+            "--output",
+            "result.json",
+            "--ai-mode",
+            "smart",
+            "--ai-provider",
+            "anthropic",
+            "--ai-model",
+            "claude-sonnet-4-5",
+            "--ai-api-key",
+            "test-key",
+        ],
+    )
+
+    assert result.exit_code == 0, f"CLI failed: {result.output}"
+    # Rich는 터미널 폭에 맞춰 줄바꿈하며 줄마다 ANSI 색상 코드를 다시 삽입하므로,
+    # 코드를 제거하고 공백도 정규화한 뒤 비교한다.
+    plain = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
+    plain = " ".join(plain.split())
+    assert "S2N-Agent 활성화" in plain
+    assert "provider=anthropic" in plain
+
+
+def test_auto_is_not_a_valid_ai_provider_choice(cli_runner):
+    """auto는 더 이상 유효한 provider가 아니다 — Ollama/HuggingFace 자동 선택 제거."""
+    result = cli_runner.invoke(
+        runner_mod.scan,
+        [
+            "--url",
+            "http://example.com",
+            "--plugin",
+            "oscommand",
+            "--ai-mode",
+            "smart",
+            "--ai-provider",
+            "auto",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "auto" in result.output.lower()

--- a/test/unit/test_runner.py
+++ b/test/unit/test_runner.py
@@ -204,7 +204,11 @@ def test_scan_output_report_error_returns_failure(cli_runner, monkeypatch, fake_
 
 def test_ai_mode_without_provider_exits_with_clear_error(cli_runner, fake_common, monkeypatch):
     """s2n-agent는 provider를 명시하지 않으면 Ollama/HuggingFace로 자동 선택하지 않고
-    ValueError를 던진다 — runner가 이걸 잡아서 traceback 대신 명확한 CLI 오류로 보여줘야 한다."""
+    ValueError를 던진다 — runner가 이걸 잡아서 traceback 대신 명확한 CLI 오류로 보여줘야 한다.
+
+    s2n-agent는 선택적(ai extra) 의존성이라 CI의 기본 [dev] 설치에는 포함되지 않는다 —
+    미설치 환경에서는 건너뛴다."""
+    pytest.importorskip("s2nagent")
     monkeypatch.delenv("S2NAGENT_PROVIDER", raising=False)
 
     result = cli_runner.invoke(
@@ -226,7 +230,8 @@ def test_ai_mode_without_provider_exits_with_clear_error(cli_runner, fake_common
 
 
 def test_ai_mode_with_explicit_provider_activates_agent(cli_runner, fake_common, monkeypatch):
-    """provider를 명시하면 AI 모드가 정상적으로 활성화된다."""
+    """provider를 명시하면 AI 모드가 정상적으로 활성화된다. s2n-agent 미설치 환경에서는 건너뛴다."""
+    pytest.importorskip("s2nagent")
     monkeypatch.delenv("S2NAGENT_PROVIDER", raising=False)
 
     result = cli_runner.invoke(


### PR DESCRIPTION
## 개요 (Overview)

s2n-agent가 provider 자동 선택(`auto`: Ollama 우선 탐지 → 안 되면 HuggingFace 폴백)을
제거하고 provider 명시를 필수로 바꿨다. 이 PR은 s2n CLI를 그 변경에 맞춘다 — 지금 상태로는
`--ai-mode`를 켜고 `--ai-provider`를 생략하면 새 s2n-agent가 `ValueError`를 던지는데,
`runner.py`는 `ImportError`만 잡고 있어서 스캔이 사용자에게 무의미한 traceback을 뿌리며
죽는다.

---

## 변경 사항 (Changes)
- `--ai-provider` Click choice에서 `auto` 제거 (더 이상 유효한 값이 아님).
- `S2NAgentPlugin` 생성 시 `ImportError`뿐 아니라 `ValueError`도 잡아서, provider 미지정
  등으로 s2n-agent가 던지는 오류를 traceback 대신 `[red]❌ AI provider 오류: ...[/red]`
  메시지 + `exit(1)`로 깔끔하게 종료.
- provider 표시 라벨(`_provider_label`)이 여전히 `"auto"`를 기본값으로 쓰고 있던 부분 수정
  — 이 지점에 `ai_provider`가 비어 있는 채로 도달할 수 있는 유일한 경우는
  `S2NAGENT_PROVIDER` 환경변수로 provider가 해석된 경우뿐이므로(그렇지 않으면 이미
  `ValueError`로 위에서 걸러짐), 환경변수 값을 읽어서 표시하도록 변경.
- `test/unit/test_runner.py`에 테스트 3개 추가:
  - provider 미지정 시 명확한 오류로 종료되는지
  - provider를 명시하면 AI 모드가 정상 활성화되는지
  - `auto`가 더 이상 유효한 선택지가 아닌지

---

## ✅ 체크리스트 (Checklist)
- [x] 코드 스타일 및 린트 검사 통과 (`ruff check s2n/s2nscanner/cli/runner.py`)
- [x] 관련 테스트 작성 및 통과 (`pytest test` — 210 passed, 신규 3건 포함)
- [ ] 관련 문서 (README 등) 업데이트 — s2n README의 `--ai-provider` 설명은 이 PR에
      포함하지 않음(범위 밖), 후속 PR에서 처리 필요
- [x] 리뷰어에게 충분히 이해될 수 있는 설명 작성

---

## 🔍 관련 이슈 (Issue)
s2n-agent 쪽 breaking change: `s2n-agent` 저장소 커밋 `838952b`
("BREAKING: require explicit LLM provider selection, remove auto fallback")

---

## 💬 비고 (Notes)
- `dev` 브랜치 기준(`origin/dev` = `202239b`)으로 새로 브랜치를 팠다 — 로컬 `dev`가
  origin과 diverge된 상태(로컬에만 있던 커밋은 `fix/on-scan-complete-hook`에도
  남아있어 유실 없음)라 로컬 `dev`는 건드리지 않았다.
- `--ai-endpoint`/`--ai-model` 기본값이 provider와 무관하게 Ollama 값
  (`http://localhost:11434`/`s2n-agent`)으로 고정된 채 전달되는 문제는 이 PR 범위 밖 —
  s2n-agent 쪽에서 이미 고친 것과 동일한 패턴의 버그지만 `interfaces.py`/`config_builder.py`/
  `mapper.py` 세 곳을 함께 손봐야 해서 별도 PR로 분리하는 게 안전하다고 판단.